### PR TITLE
Fixes for Python 3.

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -118,6 +118,9 @@ class InstallLib(install_lib):
         """ :return: list of installed packages """
         packages = []
         for package in subprocess.check_output(["pip", "freeze"]).splitlines():
+            # Python 3 fix
+            if not isinstance(package, str):
+                package = str(package, 'UTF-8')
             # installed package names look like Pillow==2.8.1, get the first part
             name = package.partition("==")[0]
             packages.append(name)
@@ -139,6 +142,9 @@ class InstallLib(install_lib):
             cmdline.extend(["show", name])
 
         output = subprocess.check_output(cmdline)
+        # Python 3 fix
+        if not isinstance(output, str):
+            output = str(output, 'UTF-8')
         # parse output that looks like this example
         """
         ---

--- a/vext/gatekeeper/__init__.py
+++ b/vext/gatekeeper/__init__.py
@@ -173,7 +173,7 @@ class GatekeeperFinder(object):
         try:
             for other_path in other_paths:
                 try:
-                    module_info = imp.find_module(fullname, other_path)
+                    module_info = imp.find_module(fullname, [other_path])
                     if module_info:
                         logger.debug("found module %s in other path [%s]", fullname, other_path)
                         return


### PR DESCRIPTION
vext didn't even install on Python 3 – `setup.py` tried to use the return value of subprocess calls as `str`, when in Py3 they're `bytes`. When you fix that and can get to install it, just opening the interpreter fails due to an error when importing anything – also fixed in this PR.

By the way, the different vext packages don't install either because the `print` call in `print "Not installing PTH file to real prefix"` is missing the parentheses.
