### PR TITLE
Fix for warning because of potentially unsafe use of ruamel.yaml.load

### DIFF
--- a/vext/gatekeeper/__init__.py
+++ b/vext/gatekeeper/__init__.py
@@ -59,7 +59,7 @@ def fix_path(p):
     """
     Convert path pointing subdirectory of virtualenv site-packages
     to system site-packages.
-    
+
     Destination directory must exist for this to work.
 
     >>> fix_path('C:\\some-venv\\Lib\\site-packages\\gnome')
@@ -297,7 +297,7 @@ def open_spec(f):
     import ruamel.yaml as yaml
 
     keys = ['modules', 'pths', 'test_import', 'install_hints', 'extra_paths']
-    data = yaml.load(f)
+    data = yaml.safe_load(f)
     parsed = dict()
     ## pattern = re.compile("^\s+|\s*,\s*|\s+$")
     for k in keys:


### PR DESCRIPTION
When installing `vext` from pip I recieved the warning message:

```
/<redacted>/lib/python2.7/site-packages/vext/gatekeeper/__init__.py:300: UnsafeLoaderWarning: 
The default 'Loader' for 'load(stream)' without further arguments can be unsafe.
Use 'load(stream, Loader=ruamel.yaml.Loader)' explicitly if that is OK.
Alternatively include the following in your code:

  import warnings
  warnings.simplefilter('ignore', ruamel.yaml.error.UnsafeLoaderWarning)

In most other cases you should consider using 'safe_load(stream)'
  data = yaml.load(f)
```

This warning appears whenever vext is loaded it seems.

Looking at the .vext file for `vext.gi` it doesn't seem to make use of any unsafe features, so I switched the function to `safe_load` instead. I have successfully used `pydbus` with `vext.gi` in a virtualenv after applying this fix.