### PR TITLE
Don't bubble up exceptions from .pth file.

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,9 @@
 language: python
 python:
   - "2.7"
-  - "3.4"
   - "3.5"
-  - "3.5-dev" # 3.5 development branch
+  - "3.6"
+  - "3.7"
   - "nightly" # currently points to 3.6-dev
 
 # command to install dependencies

--- a/vext/gatekeeper/__init__.py
+++ b/vext/gatekeeper/__init__.py
@@ -223,8 +223,13 @@ class GatekeeperFinder(object):
 
     def __init__(self, path_entry):
         self.path_entry = path_entry
-
-        sitedir = getsyssitepackages()
+        try:
+            # Wrap in exception handler in case something in a .pth file causes an exception.
+            sitedir = getsyssitepackages()
+        except Exception as e:
+            sys.stderr.write("Vext disabled:  There was an issue getting the system site packages.\n")
+            raise ImportError()
+        
         if path_entry in (sitedir, GatekeeperFinder.PATH_TRIGGER):
             logger.debug("handle entry %s", path_entry)
             return


### PR DESCRIPTION
A .pth file can have anything in it, don't die if it causes an exception.

A better solution might be to handle the files one by one, at least this stops crashes though.