### PR TITLE
Update __init__.py

### DIFF
--- a/vext/__init__.py
+++ b/vext/__init__.py
@@ -8,12 +8,10 @@ VEXT_DEBUG_LOG = "VEXT_DEBUG_LOG"
 vext_pth = join(get_python_lib(), 'vext_importer.pth')
 
 logger = logging.getLogger("vext")
-if VEXT_DEBUG_LOG in environ:
-    if environ.get(VEXT_DEBUG_LOG, "0") == "1":
-        logger.setLevel(logging.DEBUG)
-    else:
-        logger.addHandler(logging.NullHandler())
-
+if VEXT_DEBUG_LOG in environ and environ.get(VEXT_DEBUG_LOG, "0") == "1":
+    logger.setLevel(logging.DEBUG)
+else:
+    logger.addHandler(logging.NullHandler())
 
 def install_importer():
     logger.debug("install_importer has been moved to gatekeeper module")


### PR DESCRIPTION
Always add NullHandler to log so that we can avoid triggering basicConfig.


> According to the documentation，logging.basicConfig must call before call log method like debug(), info().
>
> vext.install_importer() log debug message before user code, which cause logging.basicConfig not work.