### PR TITLE
Change some ImportErrors into ModuleNotFoundErrors

### DIFF
--- a/README.md
+++ b/README.md
@@ -228,8 +228,8 @@ them to a local data structure.
 
 Logging Blocked Imports
 -----------------------
-To see which modules Vext is blocking set VEXT_LOG_BLOCKS instead of
-standard ImportErrors, you will get ones like this:
+To see which modules Vext is blocking set VEXT_LOG_BLOCKS. Instead of
+standard ModuleNotFoundErrors, you will get ones like this:
 
 
 ```bash
@@ -237,7 +237,7 @@ $ VEXT_LOG_BLOCKS=1
 ```
 ```python
 >>> import pyaudio
-ImportError("Vext blocked import of pyaudio")
+ModuleNotFoundError("Vext blocked import of pyaudio")
 ```
 
 Remembering Blocked Imports
@@ -252,7 +252,7 @@ vext.remember_blocks to True:
 >>> vext.blocked_imports
 set([])
 >>> import pygtk
-ImportError:
+ModuleNotFoundError:
 >>> vext.blocked_imports
 set(["pygtk"])
 ```
@@ -281,4 +281,3 @@ Thanks
 ruamel/venvgtk - for showing something like this is possible
 
 pymotw article on modules and imports
-

--- a/setup.py
+++ b/setup.py
@@ -329,6 +329,7 @@ setup(
         'vext.install',
     ],
 
+    python_requires=">=3.6",
     setup_requires=["setuptools>=18.0.1", "pip>=1.5.6"],
     install_requires=["ruamel.yaml>=0.11.10"],
 

--- a/vext/gatekeeper/__init__.py
+++ b/vext/gatekeeper/__init__.py
@@ -184,7 +184,7 @@ class GateKeeperLoader(object):
     def load_module(self, name):
         """
         Only lets modules in allowed_modules be loaded, others
-        will get an ImportError
+        will get a ModuleNotFoundError (a type of ImportError)
         """
 
         # Get the name relative to SITEDIR ..
@@ -198,10 +198,10 @@ class GateKeeperLoader(object):
             if remember_blocks:
                 blocked_imports.add(fullname)
             if log_blocks:
-                raise ImportError("Vext blocked import of '%s'" % modulename)
+                raise ModuleNotFoundError("Vext blocked import of '%s'" % modulename)
             else:
                 # Standard error message
-                raise ImportError("No module named %s" % modulename)
+                raise ModuleNotFoundError("No module named %s" % modulename)
 
         if name not in sys.modules:
             try:
@@ -229,7 +229,7 @@ class GatekeeperFinder(object):
         except Exception as e:
             sys.stderr.write("Vext disabled:  There was an issue getting the system site packages.\n")
             raise ImportError()
-        
+
         if path_entry in (sitedir, GatekeeperFinder.PATH_TRIGGER):
             logger.debug("handle entry %s", path_entry)
             return


### PR DESCRIPTION
[`ModuleNotFoundError`](https://docs.python.org/3/library/exceptions.html#ModuleNotFoundError) is a subclass of [`ImportError`](https://docs.python.org/3/library/exceptions.html#ImportError), new in Python 3.6. It describes a module not being available in the virtual environment (because blocked by vext) better than the more generic `ImportError`.

This PR changes `ImportError` into `ModuleNotFoundError` in function `GateKeeperLoader.load_module()`. I've let the other `ImportError`s in the code as they are, as I'm not sure about them.

Obviously a drawback of using `ModuleNotFoundError` is that it requires Python 3.6, but then again Python 3.6 was released in 2016, and as of today Python 3.7 is the oldest version still maintained.

I've tested the same way as `.travis.yml` tests, but with dependencies fixed to what they were at the time of the previous commit, Mar 24, 2021. In a new virtual environment:

```
$ pip3 install -U setuptools==54.2.0 pip==21.0.1
$ pip3 install ruamel.yaml==0.16.13 ruamel.yaml.clib==0.2.2
$ VEXT_RELOAD_HACK=1 python3 setup.py install

$ pip3 install virtualenv==20.4.3 # because required by test_virtualenv.sh
$ bash scripts/test_virtualenv.sh
```

Tests pass this way. They don't pass using current pip and setuptools. Too much has changed in these dependencies since last commit. I think `python3 setup.py ...` is now deprecated in favor of `python3 -m build`, also `virtualenv` in favor of `python3 -m venv` if I understand correctly. Here's what trying to build vext with current dependencies return, in a new virtual environment:

```
$ pip3 install -U setuptools pip
$ pip3 install -r requirements.txt
$ VEXT_RELOAD_HACK=1 python3 setup.py install
setup.py:45: DeprecationWarning: distutils Version classes are deprecated. Use packaging.version instead.
  if StrictVersion(r.version) >= StrictVersion(MIN_SETUPTOOLS):
setuptools version: 60.9.3
/home/me/.myvext/lib/python3.8/site-packages/setuptools/dist.py:738: UserWarning: Usage of dash-separated 'description-file' will not be supported in future versions. Please use the underscore name 'description_file' instead
  warnings.warn(
Traceback (most recent call last):
  File "setup.py", line 280, in <module>
    setup(
  File "/home/me/.myvext/lib/python3.8/site-packages/setuptools/__init__.py", line 154, in setup
    _install_setup_requires(attrs)
  File "/home/me/.myvext/lib/python3.8/site-packages/setuptools/__init__.py", line 148, in _install_setup_requires
    dist.fetch_build_eggs(dist.setup_requires)
  File "/home/me/.myvext/lib/python3.8/site-packages/setuptools/dist.py", line 826, in fetch_build_eggs
    resolved_dists = pkg_resources.working_set.resolve(
  File "/home/me/.myvext/lib/python3.8/site-packages/pkg_resources/__init__.py", line 739, in resolve
    requirements = list(requirements)[::-1]
  File "/home/me/.myvext/lib/python3.8/site-packages/pkg_resources/__init__.py", line 3089, in __init__
    super(Requirement, self).__init__(requirement_string)
TypeError: super(type, obj): obj must be an instance or subtype of type
```

With this modified `vext`, I confirm that I can build distribution packages for my project at work with `python3 -m build` without triggering #85, so this PR closes #85.